### PR TITLE
Added option to sync theme with browser

### DIFF
--- a/src/css/options/footer.css
+++ b/src/css/options/footer.css
@@ -1,9 +1,9 @@
 
-html[dark_mode='true'] .footer-path {
+html[dark_mode^='true'] .footer-path {
   fill: var(--body-color);
 }
 
-html[dark_mode='true'] #donate_button .footer-path  {
+html[dark_mode^='true'] #donate_button .footer-path  {
   stroke: var(--body-color);
   fill: var(--body-background-color);
 }

--- a/src/css/options/general.css
+++ b/src/css/options/general.css
@@ -1,15 +1,16 @@
 
-html[dark_mode='true'] {
+html[dark_mode^='true'] {
   --body-color: #B9B9B9;
   --body-background-color: #393939;
   --hover-fieldset-legend-color: #F9F9F9;
+  color-scheme: dark;
 }
 
-html[dark_mode='false'], html:not[dark_mode] {
+html[dark_mode^='false'] {
   --body-color: #000000;
   --body-background-color: #ffffff;
-
   --hover-fieldset-legend-color: #000000;
+  color-scheme: light;
 }
 
 html[global_enable="true"] #disabled { display: none; }

--- a/src/css/options/header.css
+++ b/src/css/options/header.css
@@ -10,8 +10,9 @@ html[global_enable="true"] #header-toggle-circle { cx: 11px }
 html[global_enable="true"] #header-toggle-outer-path { fill: green }
 
 /* Dark mode styling */
-html[dark_mode='true']  #header-light { display: none }
-html[dark_mode='false'] #header-dark  { display: none }
+html[dark_mode='true'] #header-dark { display: block }
+html[dark_mode='false'] #header-light { display: block }
+html[dark_mode*='system'] #header-system-theme  { display: block }
 
 #header-contents {
   position: relative;
@@ -52,8 +53,9 @@ html[dark_mode='false'] #header-dark  { display: none }
   -ms-transform: translateY(-50%);
   transform: translateY(-50%);
 }
-#header-light, #header-dark {
+#header-light, #header-dark, #header-system-theme {
   cursor: pointer;
+  display: none;
 }
 
 #header-toggle {

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -6,7 +6,7 @@ if (typeof browser === 'undefined') {
 // Some global constants.
 const HTML = document.documentElement;
 const SETTINGS_LIST = {
-  "dark_mode":                         { defaultValue: false, eventType: 'click' },
+  "dark_mode":                         { defaultValue: 'system', values: { system: matchMedia('(prefers-color-scheme: dark)').matches + ' system', dark: 'true', light: 'false' }, eventType: 'click' },
   "global_enable":                     { defaultValue: true,  eventType: 'click' },
 
   "remove_homepage":                   { defaultValue: true,  eventType: 'click' },
@@ -79,10 +79,10 @@ const REDIRECT_OPTIONS_TEMPLATE = REDIRECT_KEYS.reduce((options, key) => {
 document.addEventListener("DOMContentLoaded", () => {
 
   // Defaults.
-  Object.entries(SETTINGS_LIST).forEach(([key, { defaultValue: value }]) => {
+  Object.entries(SETTINGS_LIST).forEach(([key, { defaultValue: value, values }]) => {
     const settingButton = document.getElementById(key);
     if (settingButton) settingButton.checked = value;
-    HTML.setAttribute(key, value);
+    HTML.setAttribute(key, values?.[value] ?? value);
     const button = document.getElementById(key);
     if (button && 'checked' in button) button.checked = value;
   });
@@ -91,7 +91,7 @@ document.addEventListener("DOMContentLoaded", () => {
   browser && browser.storage.local.get(localSettings => {
     Object.entries(localSettings).forEach(([key, value]) => {
       if (!VALID_SETTINGS.includes(key)) return;
-      HTML.setAttribute(key, value);
+      HTML.setAttribute(key, SETTINGS_LIST[key].values ? SETTINGS_LIST[key].values[value] ?? SETTINGS_LIST[key].values[SETTINGS_LIST[key].defaultValue] : value);
       const button = document.getElementById(key);
       if (button && 'checked' in button) button.checked = value;
     });
@@ -100,20 +100,24 @@ document.addEventListener("DOMContentLoaded", () => {
 
 
 // Change settings with the options menu.
-Object.entries(SETTINGS_LIST).forEach(([key, { eventType }]) => {
+Object.entries(SETTINGS_LIST).forEach(([key, { eventType, values }]) => {
   const settingElements = Array.from(document.getElementsByClassName(key));
   settingElements.forEach(button => button.addEventListener(eventType, async e => {
 
-    // Toggle on click: new value is opposite of old value.
-    const value = !(String(HTML.getAttribute(key)).toLowerCase() === "true");
+    // Cycle on click: new value is opposite of old value, or if values is present, new value is next to the old value.
+    let value = !(String(HTML.getAttribute(key)).toLowerCase() === "true");
+    if (values) {
+      let newIndex = Object.values(values).indexOf(HTML.getAttribute(key));
+      newIndex == Object.values(values).length - 1 ? newIndex = 0 : newIndex += 1;
+      value = Object.values(values)[newIndex];
+    }
 
     // Communicate changes (to local settings, content-script.js, etc.)
     let saveObj;
 
     // Handle standard (non-redirect) settings.
     if (!key.includes('redirect')) {
-      saveObj = { [key]: value };
-
+      saveObj = { [key]: values ? Object.keys(values)[Object.values(values).indexOf(value)] : value };
       // Update background script with globalEnable.
       if (key === 'global_enable') {
         browser && browser.runtime.sendMessage({ globalEnable: value });
@@ -133,7 +137,7 @@ Object.entries(SETTINGS_LIST).forEach(([key, { eventType }]) => {
     }
 
     // Update options page.
-    Object.entries(saveObj).forEach(([key, value]) => HTML.setAttribute(key, value));
+    Object.entries(saveObj).forEach(([key, value]) => HTML.setAttribute(key, values?.[value] ?? value));
     if ('checked' in button) button.checked = value;
 
     if (browser) {

--- a/src/options.html
+++ b/src/options.html
@@ -20,6 +20,12 @@
         <div id='header-text'>Own YouTube</div>
 
         <div id='dark_mode'>
+          <a title='System Default Theme'>
+            <svg id='header-system-theme' class='dark_mode' viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+              <path fill="currentColor" d="M12 16C14.2091 16 16 14.2091 16 12C16 9.79086 14.2091 8 12 8V16Z" />
+              <path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2ZM12 4V8C9.79086 8 8 9.79086 8 12C8 14.2091 9.79086 16 12 16V20C16.4183 20 20 16.4183 20 12C20 7.58172 16.4183 4 12 4Z" fill="currentColor" />
+            </svg>
+          </a>
           <a title='Dark Mode'>
             <svg id='header-light' class='dark_mode' viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
               <circle fill="#464646" cx="12" cy="12" r="5"/>


### PR DESCRIPTION
- Default theme now matches the broswer theme
- `dark_mode`, and other options too, can now have more than two possible values. 
    - These will be cycled on `event` by the event listener.
    - Previously, options could only have `true` or `false` values
- Added `color-scheme` properties to the dark and light themes
    - This will tune the browser UI elements (scrollbars, checkboxes, etc.) to match the dark/light themes