### PR TITLE
fix: Unnecessary Padding on YouTube Homepage and Subscriptions, Alignment of contents of Watch Later and Playlist sections

### DIFF
--- a/src/chrome/css/main.css
+++ b/src/chrome/css/main.css
@@ -86,7 +86,19 @@ html[global_enable="true"][remove_entire_sidebar="true"] ytd-watch-flexy[flexy][
 	--ytd-watch-flexy-max-player-width: calc(var(--ytd-watch-flexy-chat-max-height)*var(--ytd-watch-flexy-width-ratio)/var(--ytd-watch-flexy-height-ratio)) !important
 }
 
-/* Center contents when the leftbar is completely disabled */
-html[global_enable="true"][remove_leftbar="true"] #page-manager[class="style-scope ytd-app"]{
+/* Centers the contents on the homepage and subscriptions page when sidebar is disabled */
+html[global_enable="true"][remove_leftbar="true"]
+  #page-manager[class="style-scope ytd-app"] {
+  margin-left: 0px;
+}
+
+/* Maintains the proper arrangement of the contents of watch later and playlist section */
+html[global_enable="true"][remove_leftbar="true"]
+  #contents[class="style-scope ytd-playlist-video-list-renderer"] {
+  margin-left: 240px;
+}
+
+html[global_enable="true"][remove_leftbar="true"]
+  #sort-filter-menu[class="style-scope ytd-playlist-video-list-renderer"] {
   margin-left: 240px;
 }


### PR DESCRIPTION
**Issue:**
Earlier, if the `issue 5:` **unnecessary padding on homepage and subscription page** was fixed, but `issue 9:` **disarrangement of the contents of watch later and playlist section** arises and vice-versa.

- The logic being used to fix `issue #5` earlier was: 
`margin-left: 0px;` on line 91 of the main.css 

1. **Screenshot of homepage; no unnecessary padding**
![5ehomepage](https://user-images.githubusercontent.com/84126196/206919137-85ab6a4a-ba0e-407d-b243-42847a9b31db.png)
2. **Screenshot of playlist section; disarranged**
![5eplaylist](https://user-images.githubusercontent.com/84126196/206918946-96a2b451-5191-4a79-acea-d79f333889c3.png)

- The logic being used to fix `issue #9` earlier was: 
`margin-left: 240px;` on line 91 of the main.css

1. **Screenshot of playlist section; arranged**
![9eplaylist](https://user-images.githubusercontent.com/84126196/206919787-9245dd38-45b4-4da2-afce-15c10df8e06f.png)
2. **Screenshot of homepage; unnecessary padding on the left**
![9ehomepage](https://user-images.githubusercontent.com/84126196/206919853-7bfa03b4-a808-490f-a574-e0f39c3873fe.png)

---

**Screenshots of homepage, subscription page, and playlist section respectively (after the fix):**
1. Homepage:
![image](https://user-images.githubusercontent.com/84126196/206919505-26dd2c13-e3ca-40c5-9ab4-6d456f5bb5c3.png)
2. Subscription page:
![image](https://user-images.githubusercontent.com/84126196/206919926-6095e6ce-0d6f-4ef5-a811-f2dba880c6b9.png)
3.  Playlist Section:
![9eplaylist](https://user-images.githubusercontent.com/84126196/206919787-9245dd38-45b4-4da2-afce-15c10df8e06f.png)

<h4>This pull request fixes issue #5 and issue #9 both<h4>