### PR TITLE
Added 2 new features to remove 'Explore pane' and 'More from YT pane'

### DIFF
--- a/src/chrome/css/main.css
+++ b/src/chrome/css/main.css
@@ -28,6 +28,8 @@ html[global_enable="true"][remove_yourvideos_link="true"] ytd-guide-entry-render
 html[global_enable="true"][remove_watchlater_link="true"] a[href="/playlist?list=WL"],
 html[global_enable="true"][remove_likedvideos_link="true"] a[href="/playlist?list=LL"],
 html[global_enable="true"][remove_subscriptions_pane="true"] div[id="sections"]> :nth-child(2),
+html[global_enable="true"][remove_explore_pane="true"] div[id="sections"]> :nth-child(3),
+html[global_enable="true"][remove_moreFromYT_pane="true"] div[id="sections"]> :nth-child(4),
 html[global_enable="true"][remove_footer_pane="true"] div[id="footer"],
 html[global_enable="true"][remove_premium_link="true"] a[href="/premium"],
 html[global_enable="true"][remove_films_link="true"] a[href="/feed/storefront?bp=ogUCKAI%3D"],

--- a/src/chrome/js/content-script.js
+++ b/src/chrome/js/content-script.js
@@ -32,6 +32,8 @@ const SETTINGS_LIST = {
   "remove_watchlater_link":                { defaultValue: false, eventType: 'change' },
   "remove_likedvideos_link":                { defaultValue: false, eventType: 'change' },
   "remove_subscriptions_pane":            { defaultValue: false, eventType: 'change' },
+  "remove_explore_pane":            { defaultValue: false, eventType: 'change' },
+  "remove_moreFromYT_pane":            { defaultValue: false, eventType: 'change' },
   "remove_footer_pane":            { defaultValue: false, eventType: 'change' },
   "remove_premium_link":                { defaultValue: false, eventType: 'change' },
   "remove_films_link":                { defaultValue: false, eventType: 'change' },

--- a/src/chrome/js/options.js
+++ b/src/chrome/js/options.js
@@ -32,6 +32,8 @@ const SETTINGS_LIST = {
   "remove_watchlater_link":                { defaultValue: false, eventType: 'click' },
   "remove_likedvideos_link":                { defaultValue: false, eventType: 'click' },
   "remove_subscriptions_pane":            { defaultValue: false, eventType: 'click' },
+  "remove_explore_pane":            { defaultValue: false, eventType: 'change' },
+  "remove_moreFromYT_pane":            { defaultValue: false, eventType: 'change' },
   "remove_footer_pane":            { defaultValue: false, eventType: 'click' },
   "remove_premium_link":                { defaultValue: false, eventType: 'click' },
   "remove_films_link":                { defaultValue: false, eventType: 'click' },

--- a/src/chrome/options.html
+++ b/src/chrome/options.html
@@ -250,6 +250,21 @@
             </label>
         </div>
 
+        <div>
+          <input type="checkbox" id="remove_explore_pane" class="remove_explore_pane"
+                 value="remove_explore_pane" unchecked />
+          <label for="remove_explore_pane">
+            > Explore Pane
+          </label>
+        </div>
+
+        <div>
+          <input type="checkbox" id="remove_moreFromYT_pane" class="remove_moreFromYT_pane"
+                 value="remove_moreFromYT_pane" unchecked />
+          <label for="remove_moreFromYT_pane">
+            > More from YouTube Pane
+          </label>
+      </div>
 		<br>
 		
 		<details open class="field">


### PR DESCRIPTION
**Screenshot(s):**

1. Features to remove "Explore pane" and "More from YouTube pane" added to the extension
![image](https://user-images.githubusercontent.com/84126196/207316056-2f29c0c0-6e1f-44b7-8d6c-a771c180a26a.png)

2. When the checkboxes "Explore Pane" and "More from YouTube" are **checked**; both the sections still there
![image](https://user-images.githubusercontent.com/84126196/207316364-e6ffb2a7-c230-4d47-8701-19107d07ab09.png)

3. When the checkboxes "Explore Pane" and "More from YouTube" are **unchecked**; both the sections disappear :)
![image](https://user-images.githubusercontent.com/84126196/207316740-87a8163e-ccaa-4704-8fd3-4e577444bf7c.png)
