### PR TITLE
Added feature to show/hide comments on YouTube videos

### DIFF
--- a/src/chrome/css/main.css
+++ b/src/chrome/css/main.css
@@ -60,6 +60,7 @@ html[global_enable="true"][remove_chat="true"] #chat,
 html[global_enable="true"][remove_info_cards="true"] .ytp-ce-element.ytp-ce-element,
 html[global_enable="true"][remove_menu_buttons="true"] #menu-container,
 html[global_enable="true"][remove_embedded_more_videos="true"] div.ytp-pause-overlay,
+html[global_enable="true"][remove_videoComments="true"] ytd-comments[id="comments"] > ytd-item-section-renderer[id="sections"],
 
 /* Search Results Page */
 html[global_enable="true"][on_results_page="true"][remove_extra_results="true"] ytd-shelf-renderer,
@@ -100,4 +101,18 @@ html[global_enable="true"][remove_leftbar="true"]
 html[global_enable="true"][remove_leftbar="true"]
   #sort-filter-menu[class="style-scope ytd-playlist-video-list-renderer"] {
   margin-left: 240px;
+}
+
+/* Centers the contents on the screen after video comments are removed */
+
+html[global_enable="true"][remove_videoComments="true"]
+  div#secondary {
+  margin-top: 240px;
+  margin-left: -62.5%;
+  width: 52.5%;
+}
+
+html[global_enable="true"][remove_videoComments="true"]
+  div#above-the-fold {
+    width: 85%;
 }

--- a/src/chrome/js/content-script.js
+++ b/src/chrome/js/content-script.js
@@ -34,6 +34,7 @@ const SETTINGS_LIST = {
   "remove_subscriptions_pane":            { defaultValue: false, eventType: 'change' },
   "remove_explore_pane":            { defaultValue: false, eventType: 'change' },
   "remove_moreFromYT_pane":            { defaultValue: false, eventType: 'change' },
+  "remove_videoComments":            { defaultValue: false, eventType: 'change' },
   "remove_footer_pane":            { defaultValue: false, eventType: 'change' },
   "remove_premium_link":                { defaultValue: false, eventType: 'change' },
   "remove_films_link":                { defaultValue: false, eventType: 'change' },

--- a/src/chrome/js/options.js
+++ b/src/chrome/js/options.js
@@ -34,6 +34,7 @@ const SETTINGS_LIST = {
   "remove_subscriptions_pane":            { defaultValue: false, eventType: 'click' },
   "remove_explore_pane":            { defaultValue: false, eventType: 'change' },
   "remove_moreFromYT_pane":            { defaultValue: false, eventType: 'change' },
+  "remove_videoComments":            { defaultValue: false, eventType: 'change' },
   "remove_footer_pane":            { defaultValue: false, eventType: 'click' },
   "remove_premium_link":                { defaultValue: false, eventType: 'click' },
   "remove_films_link":                { defaultValue: false, eventType: 'click' },

--- a/src/chrome/options.html
+++ b/src/chrome/options.html
@@ -413,6 +413,14 @@
               <img class="tooltip" src="images/tooltip.svg" title="Redirects the autoplaying 'shorts' player to the regular video player.">
             </label>
         </div>
+        
+        <div>
+          <input type="checkbox" id="remove_videoComments" class="remove_videoComments"
+                 value="remove_videoComments" unchecked />
+          <label for="remove_videoComments">
+            Video Comments
+          </label>
+        </div>
 
         <hr style="margin-top: 15px">
         <div><b>Remove element options</b></div>


### PR DESCRIPTION
**Screenshot(s):**

1. Added a feature to show/hide YouTube video comments under `Video player > Dynamic options`
![image](https://user-images.githubusercontent.com/84126196/207356733-5b8f80c2-714e-4541-9da0-b1bc70d6b36e.png)

2. When the `Video Comments` checkbox is **checked**; comments are present
![image](https://user-images.githubusercontent.com/84126196/207357143-8b12d86f-7b33-4998-82fd-ebd3ab9328d5.png)

3. When the `Video Comments` checkbox is **unchecked**; comments are gone and remaining contents are **centered**
a. 
![image](https://user-images.githubusercontent.com/84126196/207357433-110dcd3d-9e06-4ffb-9f08-914b9612a63e.png)
b.
![image](https://user-images.githubusercontent.com/84126196/207357511-d60fff24-2774-450b-b87a-e183ae99c7a3.png)