### PR TITLE
Added feature to show/hide complete top bar also fixed a minor typo in the code

### DIFF
--- a/src/chrome/css/main.css
+++ b/src/chrome/css/main.css
@@ -14,6 +14,7 @@ html[global_enable="true"][remove_end_of_video="true"] .html5-endscreen,
 html[global_enable="true"][remove_youtubeapps="true"] yt-icon-button[class="style-scope ytd-topbar-menu-button-renderer style-default"],
 html[global_enable="true"][remove_avatar="true"] button[id="avatar-btn"],
 html[global_enable="true"][remove_notification="true"] yt-icon-button[class="style-scope ytd-notification-topbar-button-renderer"],
+html[global_enable="true"][remove_top_bar="true"] div#end > div#buttons,
 
 /* Left Bar Navigation */
 html[global_enable="true"][remove_home_link="true"] a:not(#logo)[href="/"],

--- a/src/chrome/js/content-script.js
+++ b/src/chrome/js/content-script.js
@@ -12,9 +12,10 @@ const SETTINGS_LIST = {
   "remove_homepage":                   { defaultValue: true,  eventType: 'change' },
   "remove_sidebar":                    { defaultValue: true,  eventType: 'change' },
   "remove_leftbar":                    { defaultValue: true,  eventType: 'change' },
-  "remove_avatar":                    { defaultValue: true,  eventType: 'change' },
-  "remove_notification":                    { defaultValue: true,  eventType: 'change' },
-  "remove_youtubeapps":                    { defaultValue: true,  eventType: 'change' },
+  "remove_avatar":                    { defaultValue: false,  eventType: 'change' },
+  "remove_top_bar":                    { defaultValue: true,  eventType: 'change' },
+  "remove_notification":                    { defaultValue: false,  eventType: 'change' },
+  "remove_youtubeapps":                    { defaultValue: false,  eventType: 'change' },
   "remove_end_of_video":               { defaultValue: true,  eventType: 'change' },
 
   "remove_all_but_one":                { defaultValue: false, eventType: 'change' },

--- a/src/chrome/js/options.js
+++ b/src/chrome/js/options.js
@@ -12,9 +12,10 @@ const SETTINGS_LIST = {
   "remove_homepage":                   { defaultValue: true,  eventType: 'click' },
   "remove_sidebar":                    { defaultValue: true,  eventType: 'click' },
   "remove_leftbar":                    { defaultValue: true,  eventType: 'click' },
-  "remove_avatar":                    { defaultValue: true,  eventType: 'click' },
-  "remove_notification":                    { defaultValue: true,  eventType: 'click' },
-  "remove_youtubeapps":                    { defaultValue: true,  eventType: 'click' },
+  "remove_avatar":                    { defaultValue: false,  eventType: 'click' },
+  "remove_top_bar":                    { defaultValue: true,  eventType: 'change' },
+  "remove_notification":                    { defaultValue: false,  eventType: 'click' },
+  "remove_youtubeapps":                    { defaultValue: false,  eventType: 'click' },
   "remove_end_of_video":               { defaultValue: true,  eventType: 'click' },
 
   "remove_all_but_one":                { defaultValue: false, eventType: 'click' },

--- a/src/chrome/options.html
+++ b/src/chrome/options.html
@@ -92,7 +92,16 @@
 		
 		<hr style="margin-top: 15px">
         <div><b>Top bar elements</b></div>
-		
+        
+        <div>
+          <input type="checkbox" id="remove_top_bar" class="remove_top_bar"
+                 value="remove_top_bar" checked />
+          <label for="remove_top_bar">
+            >> Complete Top Bar
+            <img class="tooltip" src="images/tooltip.svg" title="Removes top bar elements except search and YouTube logo">
+          </label>
+        </div>
+
         <div>
             <input type="checkbox" id="remove_youtubeapps" class="remove_youtubeapps"
                    value="remove_youtubeapps" checked />
@@ -111,7 +120,7 @@
 
         <div>
             <input type="checkbox" id="remove_avatar" class="remove_avatar"
-                   value="removeavremove_avatar" checked />
+                   value="remove_avatar" checked />
             <label for="remove_avatar">
               Avatar
             </label>


### PR DESCRIPTION
**Screenshot(s)**

1. By default, the top bar isn't present there (YouTube Create, Notifications and Avatar); **as expected**, since the "Complete Top Bar" checkbox is currently unchecked
![image](https://user-images.githubusercontent.com/84126196/207935348-a5260dce-bf41-4536-9e39-c4951e8401b5.png)

2. Once "Complete Top Bar" checkbox is **checked**; the complete top bar appears
![image](https://user-images.githubusercontent.com/84126196/207935984-f2311c1d-2e57-40e7-a333-b88e5c02c662.png)

<p text-align="center">If the user wants to, they can manually hide one, two, all three elements of the top bar by tapping onto the respective checkboxes</p>

---

**Typo** at `line 114` of options.html was fixed