### PR TITLE
fix (minor): Functioning of 'Menu buttons' switch

### DIFF
--- a/src/chrome/css/main.css
+++ b/src/chrome/css/main.css
@@ -60,7 +60,7 @@ html[global_enable="true"][remove_comments="true"] ytd-engagement-panel-section-
 html[global_enable="true"][remove_chat="true"] #chat,
 html[global_enable="true"][remove_info_cards="true"] div#iv-drawer,
 html[global_enable="true"][remove_info_cards="true"] button[class="ytp-button ytp-cards-button"] > span[class="ytp-cards-button-icon-default"] > div.ytp-cards-button-icon,
-html[global_enable="true"][remove_menu_buttons="true"] #menu-container,
+html[global_enable="true"][remove_menu_buttons="true"] #menu,
 html[global_enable="true"][remove_embedded_more_videos="true"] div.ytp-pause-overlay,
 html[global_enable="true"][remove_videoComments="true"] ytd-comments[id="comments"] > ytd-item-section-renderer[id="sections"],
 

--- a/src/firefox/css/main.css
+++ b/src/firefox/css/main.css
@@ -60,7 +60,7 @@ html[global_enable="true"][remove_comments="true"] ytd-engagement-panel-section-
 html[global_enable="true"][remove_chat="true"] #chat,
 html[global_enable="true"][remove_info_cards="true"] div#iv-drawer,
 html[global_enable="true"][remove_info_cards="true"] button[class="ytp-button ytp-cards-button"] > span[class="ytp-cards-button-icon-default"] > div.ytp-cards-button-icon,
-html[global_enable="true"][remove_menu_buttons="true"] #menu-container,
+html[global_enable="true"][remove_menu_buttons="true"] #menu,
 html[global_enable="true"][remove_embedded_more_videos="true"] div.ytp-pause-overlay,
 html[global_enable="true"][remove_videoComments="true"] ytd-comments[id="comments"] > ytd-item-section-renderer[id="sections"],
 


### PR DESCRIPTION
Earlier the "menu button" switch did not remove menu items (Like, Dislike, Share etc.) whether on/off.

- **Screenshots (before the fix):**
![image](https://user-images.githubusercontent.com/84126196/209970163-5d17a523-b8ec-4bab-8e34-1803959be46a.png)
![image](https://user-images.githubusercontent.com/84126196/209970766-a6408aa8-e346-4a46-8673-8a2517649468.png)

- **Screenshots (after the fix):**
a. Switch off; menu present:
![image](https://user-images.githubusercontent.com/84126196/209970877-7ce49916-0eef-41ae-b0ae-e7a2cd10043a.png)
b. Switch on; menu gone:
![image](https://user-images.githubusercontent.com/84126196/209970573-485c20e8-0460-476d-8071-3dccaeedc461.png)
