### PR TITLE
refactor: Removed the repetitive code for show/hide Comments feature

### DIFF
--- a/src/chrome/css/main.css
+++ b/src/chrome/css/main.css
@@ -54,9 +54,7 @@ html[global_enable="true"][remove_extra_rows="true"] ytd-rich-grid-renderer > #c
 /* Video Player */
 html[global_enable="true"][remove_entire_sidebar="true"] #secondary,
 html[global_enable="true"][remove_play_next_button="true"] a.ytp-next-button,
-html[global_enable="true"][remove_comments="true"] #comments,
-html[global_enable="true"][remove_comments="true"] #comment-teaser,
-html[global_enable="true"][remove_comments="true"] ytd-engagement-panel-section-list-renderer[target-id="engagement-panel-comments-section"],
+[target-id="engagement-panel-comments-section"],
 html[global_enable="true"][remove_chat="true"] #chat,
 html[global_enable="true"][remove_info_cards="true"] div#iv-drawer,
 html[global_enable="true"][remove_info_cards="true"] button[class="ytp-button ytp-cards-button"] > span[class="ytp-cards-button-icon-default"] > div.ytp-cards-button-icon,

--- a/src/chrome/js/content-script.js
+++ b/src/chrome/js/content-script.js
@@ -57,7 +57,6 @@ const SETTINGS_LIST = {
   "remove_info_cards":                 { defaultValue: false, eventType: 'change' },
   "remove_play_next_button":           { defaultValue: false, eventType: 'change' },
   "remove_menu_buttons":               { defaultValue: false, eventType: 'change' },
-  "remove_comments":                   { defaultValue: false, eventType: 'change' },
   "remove_chat":                       { defaultValue: false, eventType: 'change' },
   "remove_embedded_more_videos":       { defaultValue: false, eventType: 'change' },
 

--- a/src/chrome/js/options.js
+++ b/src/chrome/js/options.js
@@ -57,7 +57,6 @@ const SETTINGS_LIST = {
   "remove_info_cards":                 { defaultValue: false, eventType: 'click' },
   "remove_play_next_button":           { defaultValue: false, eventType: 'click' },
   "remove_menu_buttons":               { defaultValue: false, eventType: 'change' },
-  "remove_comments":                   { defaultValue: false, eventType: 'click' },
   "remove_chat":                       { defaultValue: false, eventType: 'click' },
   "remove_embedded_more_videos":       { defaultValue: false, eventType: 'click' },
 

--- a/src/chrome/options.html
+++ b/src/chrome/options.html
@@ -464,13 +464,7 @@
             </label>
         </div>
 
-        <div>
-            <input type="checkbox" id="remove_comments" class="remove_comments"
-                   value="remove_comments" unchecked />
-            <label for="remove_comments">
-              Comments
-            </label>
-        </div>
+        
 
         <div>
             <input type="checkbox" id="remove_chat" class="remove_chat"

--- a/src/firefox/css/main.css
+++ b/src/firefox/css/main.css
@@ -54,9 +54,7 @@ html[global_enable="true"][remove_extra_rows="true"] ytd-rich-grid-renderer > #c
 /* Video Player */
 html[global_enable="true"][remove_entire_sidebar="true"] #secondary,
 html[global_enable="true"][remove_play_next_button="true"] a.ytp-next-button,
-html[global_enable="true"][remove_comments="true"] #comments,
-html[global_enable="true"][remove_comments="true"] #comment-teaser,
-html[global_enable="true"][remove_comments="true"] ytd-engagement-panel-section-list-renderer[target-id="engagement-panel-comments-section"],
+[target-id="engagement-panel-comments-section"],
 html[global_enable="true"][remove_chat="true"] #chat,
 html[global_enable="true"][remove_info_cards="true"] div#iv-drawer,
 html[global_enable="true"][remove_info_cards="true"] button[class="ytp-button ytp-cards-button"] > span[class="ytp-cards-button-icon-default"] > div.ytp-cards-button-icon,

--- a/src/firefox/js/content-script.js
+++ b/src/firefox/js/content-script.js
@@ -57,7 +57,6 @@ const SETTINGS_LIST = {
   "remove_info_cards":                 { defaultValue: false, eventType: 'change' },
   "remove_play_next_button":           { defaultValue: false, eventType: 'change' },
   "remove_menu_buttons":               { defaultValue: false, eventType: 'change' },
-  "remove_comments":                   { defaultValue: false, eventType: 'change' },
   "remove_chat":                       { defaultValue: false, eventType: 'change' },
   "remove_embedded_more_videos":       { defaultValue: false, eventType: 'change' },
 

--- a/src/firefox/js/options.js
+++ b/src/firefox/js/options.js
@@ -57,7 +57,6 @@ const SETTINGS_LIST = {
   "remove_info_cards":                 { defaultValue: false, eventType: 'click' },
   "remove_play_next_button":           { defaultValue: false, eventType: 'click' },
   "remove_menu_buttons":               { defaultValue: false, eventType: 'change' },
-  "remove_comments":                   { defaultValue: false, eventType: 'click' },
   "remove_chat":                       { defaultValue: false, eventType: 'click' },
   "remove_embedded_more_videos":       { defaultValue: false, eventType: 'click' },
 

--- a/src/firefox/options.html
+++ b/src/firefox/options.html
@@ -464,13 +464,7 @@
             </label>
         </div>
 
-        <div>
-            <input type="checkbox" id="remove_comments" class="remove_comments"
-                   value="remove_comments" unchecked />
-            <label for="remove_comments">
-              Comments
-            </label>
-        </div>
+        
 
         <div>
             <input type="checkbox" id="remove_chat" class="remove_chat"


### PR DESCRIPTION
A repetitive feature to show/hide comments was already present, that was just hiding the comments and not centering the contents on the screen. Hence, removed.