### PR TITLE
fix: redundant spacing on YouTube's homepage and subscriptions, and content misalignment in watch later/ playlists section

### DIFF
--- a/src/chrome/css/main.css
+++ b/src/chrome/css/main.css
@@ -99,21 +99,8 @@ html[global_enable="true"][remove_leftbar="true"]
 }
 
 /* Maintains the proper arrangement of the contents of watch later and playlist section */
-html[global_enable="true"][remove_leftbar="true"]
-  #contents[class="style-scope ytd-playlist-video-list-renderer"] {
+html[global_enable="true"][remove_leftbar="true"] ytd-browse[page-subtype="playlist"]{
   margin-left: 240px;
-}
-
-html[global_enable="true"][remove_leftbar="true"]
-  #sort-filter-menu[class="style-scope ytd-playlist-video-list-renderer"] {
-  margin-left: 240px;
-}
-
-/* Maintains the proper alignment of alertboxes in watch later and playlist section whenever they occur; they do not occur everytime */
-html[global_enable="true"][remove_leftbar="true"]
-  ytd-browse > div#alerts > ytd-alert-with-button-renderer {
-  margin-left: 240px;
-  width: 70%;
 }
 
 /* Centers the contents on the screen after video comments are removed */

--- a/src/firefox/css/main.css
+++ b/src/firefox/css/main.css
@@ -99,21 +99,8 @@ html[global_enable="true"][remove_leftbar="true"]
 }
 
 /* Maintains the proper arrangement of the contents of watch later and playlist section */
-html[global_enable="true"][remove_leftbar="true"]
-  #contents[class="style-scope ytd-playlist-video-list-renderer"] {
+html[global_enable="true"][remove_leftbar="true"] ytd-browse[page-subtype="playlist"]{
   margin-left: 240px;
-}
-
-html[global_enable="true"][remove_leftbar="true"]
-  #sort-filter-menu[class="style-scope ytd-playlist-video-list-renderer"] {
-  margin-left: 240px;
-}
-
-/* Maintains the proper alignment of alertboxes in watch later and playlist section whenever they occur; they do not occur everytime */
-html[global_enable="true"][remove_leftbar="true"]
-  ytd-browse > div#alerts > ytd-alert-with-button-renderer {
-  margin-left: 240px;
-  width: 70%;
 }
 
 /* Centers the contents on the screen after video comments are removed */


### PR DESCRIPTION
Fixes #41 

- No misalignment in watch later/ playlists:

https://github.com/proffapt/own-youtube/assets/138142257/a0cf2f2d-9ad1-4d26-b300-1f30caf9d2ad

- No redundant spacing on homepage and subscriptions:

<img src="https://github.com/proffapt/own-youtube/assets/138142257/60bdadf8-bfb5-490d-99bf-a3fab97c0667" width="49%" height="auto"/>
<img src="https://github.com/proffapt/own-youtube/assets/138142257/6ea2e732-f5c7-42bc-85f2-f709205b49ea" width="49%" height="auto"/>



